### PR TITLE
remove unused permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "An IDE used for creating / managing bookmarklets",
   "author": "ddavison",
   "homepage_url": "https://github.com/ddavison/chrome-bookmarklet-ide",
-  "version": "1.4",
+  "version": "1.4.1",
   "manifest_version": 2,
   "browser_action": {
     "default_title": "Bookmarklet IDE",
@@ -30,7 +30,6 @@
   "offline_enabled": true,
 
   "permissions": [
-    "tabs",
     "bookmarks",
     "storage",
     "contextMenus"


### PR DESCRIPTION
To abide by Chrome Developer Guidelines ...

Use of Permissions:

Violation reference ID: Purple Potassium
Violation: Requesting but not using the following permission(s): **tabs**

How to rectify: Remove the above permission(s)

Relevant section of the program policy:
Request access to the narrowest permissions necessary to implement your Product's features or services. Don't attempt to "future proof" your Product by requesting a permission that might benefit services or features that have not yet been implemented. [(learn more)](https://developer.chrome.com/webstore/program_policies#permissions)